### PR TITLE
fixed Issue with Deprecated Options in Uncrustify Configuration

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -60,7 +60,7 @@ sp_assign                       = add   # ignore/add/remove/force
 sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
 
 # Add or remove space after the capture specification in C++11 lambda.
-# sp_cpp_lambda_paren             = ignore   # ignore/add/remove/force
+sp_cpp_lambda_square_paren            = ignore   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=' in a prototype
 sp_assign_default               = add   # ignore/add/remove/force
@@ -451,7 +451,7 @@ sp_try_brace                    = force   # ignore/add/remove/force
 sp_getset_brace                 = force   # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add
-# sp_word_brace                   = force      # ignore/add/remove/force
+sp_type_brace_init_lst                    = force      # ignore/add/remove/force
 
 # Add or remove space between a variable and '{' for a namespace. Default=Add
 sp_word_brace_ns                = force      # ignore/add/remove/force
@@ -558,10 +558,10 @@ sp_inside_newop_paren_open      = force   # ignore/add/remove/force
 sp_inside_newop_paren_close     = remove   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment
-sp_before_tr_cmt            = ignore   # ignore/add/remove/force
+sp_before_tr_emb_cmt            = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment
-sp_num_before_tr_cmt        = 0        # unsigned number
+sp_num_before_tr_emb_cmt        = 0        # unsigned number
 
 # Control space between a Java annotation and the open paren.
 sp_annotation_paren             = ignore   # ignore/add/remove/force
@@ -715,7 +715,7 @@ indent_func_throw               = 0        # unsigned number
 indent_member                   = 0        # unsigned number
 
 # Spaces to indent single line ('//') comments on lines before code
-indent_single_line_comments_before       = 0        # unsigned number
+indent_sing_line_comments       = 0        # unsigned number
 
 # If set, will indent trailing single line ('//') comments relative
 # to the code instead of trying to keep the same absolute column

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -558,10 +558,10 @@ sp_inside_newop_paren_open      = force   # ignore/add/remove/force
 sp_inside_newop_paren_close     = remove   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment
-sp_before_tr_emb_cmt            = ignore   # ignore/add/remove/force
+sp_before_tr_cmt            = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment
-sp_num_before_tr_emb_cmt        = 0        # unsigned number
+sp_num_before_tr_cmt        = 0        # unsigned number
 
 # Control space between a Java annotation and the open paren.
 sp_annotation_paren             = ignore   # ignore/add/remove/force
@@ -675,7 +675,8 @@ indent_var_def_cont             = false    # false/true
 
 # Indent continued shift expressions ('<<' and '>>') instead of aligning.
 # Turn align_left_shift off when enabling this.
-indent_shift                    = false    # false/true
+#indent_shift                    = 4    # false/true
+
 
 # True:  force indentation of function definition to start in column 1
 # False: use the default behavior
@@ -715,7 +716,7 @@ indent_func_throw               = 0        # unsigned number
 indent_member                   = 0        # unsigned number
 
 # Spaces to indent single line ('//') comments on lines before code
-indent_sing_line_comments       = 0        # unsigned number
+indent_single_line_comments_before       = 0        # unsigned number
 
 # If set, will indent trailing single line ('//') comments relative
 # to the code instead of trying to keep the same absolute column
@@ -761,13 +762,13 @@ indent_paren_nl                 = false    # false/true
 indent_paren_close              = 0        # unsigned number
 
 # Controls the indent of a comma when inside a paren.If True, aligns under the open paren
-indent_comma_paren              = false    # false/true
+indent_comma_paren              = 1    # false/true
 
 # Controls the indent of a BOOL operator when inside a paren.If True, aligns under the open paren
-indent_bool_paren               = false    # false/true
+indent_bool_paren               = 1    # false/true
 
 # If 'indent_bool_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones
-indent_first_bool_expr          = false    # false/true
+indent_first_bool_expr          = true    # false/true
 
 # If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
 indent_square_nl                = false    # false/true
@@ -854,7 +855,7 @@ nl_after_square_assign          = ignore   # ignore/add/remove/force
 
 # The number of blank lines after a block of variable definitions at the top of a function body
 # 0 = No change (default)
-nl_func_var_def_blk             = 1        # unsigned number
+nl_var_def_blk_end_func_top             = 1        # unsigned number
 
 # The number of newlines before a block of typedefs
 # 0 = No change (default)
@@ -1582,7 +1583,7 @@ align_single_line_brace_gap     = 1        # unsigned number
 
 # Whether to align macros wrapped with a backslash and a newline.
 # This will not work right if the macro contains a multi-line comment.
-align_nl_cont                   = true    # false/true
+align_nl_cont                   = 1    # false/true
 
 # # Align macro functions and variables together
 align_pp_define_together        = false    # false/true
@@ -1702,7 +1703,7 @@ mod_full_brace_if               = force   # ignore/add/remove/force
 
 # Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
 # If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
-mod_full_brace_if_chain         = false    # false/true
+mod_full_brace_if_chain         = 1    # false/true
 
 # Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
 # If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
@@ -1793,7 +1794,7 @@ pp_indent_at_level              = false    # false/true
 pp_indent_count                 = 1        # unsigned number
 
 # Add or remove space after # based on pp_level of #if blocks
-pp_space                        = ignore   # ignore/add/remove/force
+pp_space_after                        = ignore   # ignore/add/remove/force
 
 # Sets the number of spaces added with pp_space
 pp_space_count                  = 0        # unsigned number


### PR DESCRIPTION
Hello
I hope this message finds you well. In `Qt Creator 11.0.0` and `Uncrustify-0.72.0` I had this Error:

```
Error in text formatting: uncrustify: /home/parisa/codestyle/uncrustify.cfg:63: option 'sp_cpp_lambda_paren' is deprecated; use 'sp_cpp_lambda_square_paren' instead
/home/parisa/codestyle/uncrustify.cfg:454: option 'sp_word_brace' is deprecated; did you want to use 'sp_type_brace_init_lst' instead?
```
I'm encountering deprecated options that are causing problems when attempting to format code.

In my usage of Uncrustify, I've noticed that the following options in the configuration file have been marked as deprecated:

    sp_cpp_lambda_paren is deprecated. The recommended replacement is sp_cpp_lambda_square_paren.
    sp_word_brace is deprecated. The recommended replacement is sp_type_brace_init_lst


Best regards,
Parisa

